### PR TITLE
fix link to hackerone

### DIFF
--- a/.github/ISSUE_TEMPLATE/security.md
+++ b/.github/ISSUE_TEMPLATE/security.md
@@ -13,7 +13,7 @@ Please read our [SECURITY.md](https://github.com/fastify/.github/blob/main/SECUR
 Individuals who find potential vulnerabilities in a package are invited
 to complete a vulnerability report on the dedicated HackerOne organization:
 
-[https://hackerone.com/fastify](https://hackerone.com/fasity)
+[https://hackerone.com/fastify](https://hackerone.com/fastify)
 
 Vulnerabilities can also be reported by emailing to Fastify core members: 
 


### PR DESCRIPTION
fixes a typo in the url 

typo was introduced 22 days ago with:
https://github.com/fastify/.github/commit/e372afc8cef3e188cbbf8a122c29c47cfe52af4d