### PR TITLE
chore(issue_template/bug): replace steps to reproduce with mre input

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -23,7 +23,7 @@ body:
     id: fastify-version
     attributes:
       label: Fastify version
-      placeholder: 3.x.x
+      placeholder: 4.x.x
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -2,7 +2,6 @@ name: 🐛 Bug report
 description: Create a report to help us improve
 
 body:
-
   - type: markdown
     attributes:
       value: |
@@ -14,11 +13,11 @@ body:
     attributes:
       label: Prerequisites
       options:
-      - label: I have written a descriptive issue title
-        required: true
-      - label: | 
-          I have searched existing issues to ensure the bug has not already been reported
-        required: true
+        - label: I have written a descriptive issue title
+          required: true
+        - label: |
+            I have searched existing issues to ensure the bug has not already been reported
+          required: true
 
   - type: input
     id: fastify-version
@@ -75,6 +74,12 @@ body:
       description: |
         A link to a **public** GitHub repository containing a [minimal reproducible example](https://en.wikipedia.org/wiki/Minimal_reproducible_example) (MRE).
         It should be the bare minimum code needed to trigger the issue, and easily runnable without any changes or extra code.
+        Code should not be in a meta-framework like Next.js, Gatsby, etc.
+
+        Examples of MREs:
+        - https://github.com/fastify/fastify/issues/3617
+        - https://github.com/fastify/fastify/issues/2990
+        - https://github.com/fastify/fastify/issues/3094
 
   - type: textarea
     id: expected-behavior

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -38,7 +38,7 @@ body:
     id: node-version
     attributes:
       label: Node.js version
-      placeholder: 14.x
+      placeholder: 18.x
     validations:
       required: true
 
@@ -68,15 +68,13 @@ body:
     validations:
       required: true
 
-  - type: textarea
-    id: steps-to-reproduce
+  - type: input
+    id: mre
     attributes:
-      label: Steps to Reproduce
+      label: Link to code that reproduces the bug
       description: |
-        List of steps, sample code, or a link to code or a project that reproduces the behavior.
-        Make sure you place a stack trace inside a [code (```) block](https://docs.github.com/en/github/writing-on-github/creating-and-highlighting-code-blocks) to avoid linking unrelated issues.
-    validations:
-      required: true
+        A link to a **public** GitHub repository containing a [minimal reproducible example](https://en.wikipedia.org/wiki/Minimal_reproducible_example) (MRE).
+        It should be the bare minimum code needed to trigger the issue, and easily runnable without any changes or extra code.
 
   - type: textarea
     id: expected-behavior


### PR DESCRIPTION
closes #33
closes #5

Stops users from reporting issues, dumping code into code blocks, and expecting us to build a project from it.

Also bumped the placedholder Node version whilst I was in the area.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
