### PR TITLE
docs: update security reporting to use GitHub Security Advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,13 @@ project and its official plugins.
 ## Reporting vulnerabilities
 
 Individuals who find potential vulnerabilities in Fastify are invited to
-complete a vulnerability report via the GitHub Security Advisory:
-[https://github.com/fastify/fastify/security/advisories/new](https://github.com/fastify/fastify/security/advisories/new).
+complete a vulnerability report via the [GitHub Security Advisory][advisory].
+
+> **Note:** Historically, the Fastify project used [HackerOne](https://hackerone.com/fastify)
+> for vulnerability reporting. That program is now closed. All new vulnerability
+> reports should be submitted through GitHub Security Advisories of the individual projects.
+
+[advisory]: ../../security/advisories/new
 
 ### Strict measures when reporting vulnerabilities
 


### PR DESCRIPTION
## Summary

- Update SECURITY.md to use a relative link (`../../security/advisories/new`) that points to each repository's own GitHub Security Advisory page
- Add historical note about HackerOne program closure
- Clarify that vulnerability reports should go to GitHub Security Advisories of the individual projects

Ref: https://github.com/fastify/fastify/issues/6468