### PR TITLE
docs: sync SECURITY.md with latest Fastify policy changes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,14 +3,59 @@
 This document describes the management of vulnerabilities for the Fastify
 project and its official plugins.
 
+## Threat Model
+
+Fastify's threat model extends the
+[Node.js threat model](https://github.com/nodejs/node/blob/main/SECURITY.md#the-nodejs-threat-model).
+
+**Trusted:** Application code (plugins, handlers, hooks, schemas), configuration,
+and the runtime environment.
+
+**Untrusted:** All network input (HTTP headers, body, query strings, URL
+parameters).
+
+### Examples of Vulnerabilities
+
+- Parsing flaws that bypass validation or security controls
+- DoS through malformed input to Fastify's core
+- Bypasses of built-in protections (prototype poisoning, schema validation)
+
+### Examples of Non-Vulnerabilities
+
+The following are **not** considered vulnerabilities in Fastify:
+
+- **Application code vulnerabilities**: XSS, SQL injection, or other flaws in
+user-written route handlers, hooks, or plugins
+- **Malicious application code**: Issues caused by intentionally malicious
+plugins or handlers (application code is trusted)
+- **Validation schema issues**: Weak or incorrect schemas provided by developers
+(schemas are trusted)
+- **ReDoS in user patterns**: Regular expression DoS in user-provided regex
+patterns for routes or validation
+- **Missing security features**: Lack of rate limiting, authentication, or
+authorization (these are application-level concerns)
+- **Configuration mistakes**: Security issues arising from developer
+misconfiguration (configuration is trusted)
+- **Third-party dependencies**: Vulnerabilities in npm packages used by the
+application (not Fastify core dependencies)
+- **Resource exhaustion from handlers**: DoS caused by expensive operations in
+user route handlers
+- **Information disclosure by design**: Exposing error details or stack traces
+explicitly enabled via configuration options
+
 ## Reporting vulnerabilities
 
 Individuals who find potential vulnerabilities in Fastify are invited to
-complete a vulnerability report via the [GitHub Security Advisory][advisory].
+complete a vulnerability report via the
+[GitHub Security page][advisory].
 
-> **Note:** Historically, the Fastify project used [HackerOne](https://hackerone.com/fastify)
-> for vulnerability reporting. That program is now closed. All new vulnerability
-> reports should be submitted through GitHub Security Advisories of the individual projects.
+Do not assign or request a CVE directly.
+CVE assignment is handled by the Fastify Security Team.
+Fastify falls under the [OpenJS CNA](https://cna.openjsf.org/).
+A CVE will be assigned as part of our responsible disclosure process.
+
+> ℹ️ Note:
+> Fastify's [HackerOne](https://hackerone.com/fastify) program is now closed.
 
 [advisory]: ../../security/advisories/new
 
@@ -20,13 +65,13 @@ It is of the utmost importance that you read carefully and follow these
 guidelines to ensure the ecosystem as a whole isn't disrupted due to improperly
 reported vulnerabilities:
 
-* Avoid creating new "informative" reports on GitHub Security Advisory. Only create new
-  security reports on a vulnerability if you are absolutely sure this should be
+* Avoid creating new "informative" reports. Only create new
+  reports on a vulnerability if you are absolutely sure this should be
   tagged as an actual vulnerability. Third-party vendors and individuals are
-  tracking any new vulnerabilities reported in GitHub Security Advisory and will flag them as
-  such for their customers (think about snyk, npm audit, ...).
+  tracking any new vulnerabilities reported on GitHub and will flag
+  them as such for their customers (think about snyk, npm audit, ...).
 * Security reports should never be created and triaged by the same person. If
-  you are creating a security report for a vulnerability that you found, or on
+  you are creating a report for a vulnerability that you found, or on
   behalf of someone else, there should always be a 2nd Security Team member who
   triages it. If in doubt, invite more Fastify Collaborators to help triage the
   validity of the report. In any case, the report should follow the same process
@@ -44,8 +89,8 @@ reported vulnerabilities:
 
 ### Vulnerabilities found outside this process
 
-⚠ The Fastify project does not support any reporting outside the GitHub Security Advisory
-process described in this document.
+⚠ The Fastify project does not support any reporting outside the process mentioned
+in this document.
 
 ## Handling vulnerability reports
 
@@ -59,16 +104,14 @@ Within 4 business days, a member of the security team provides a first answer to
 the individual who submitted the potential vulnerability. The possible responses
 can be:
 
-* Acceptance: what was reported is considered as a new vulnerability
-* Rejection: what was reported is not considered as a new vulnerability
-* Need more information: the security team needs more information in order to
+* **Acceptance**: what was reported is considered as a new vulnerability
+* **Rejection**: what was reported is not considered as a new vulnerability
+* **Need more information**: the security team needs more information in order to
   evaluate what was reported.
 
 Triaging should include updating issue fields:
 * Asset - set/create the module affected by the report
 * Severity - TBD, currently left empty
-
-Reference: [GitHub Security Advisory](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/creating-a-repository-security-advisory)
 
 ### Correction follow-up
 
@@ -103,14 +146,22 @@ If the package maintainer is actively developing a patch, an additional delay
 can be added with the approval of the security team and the individual who
 reported the vulnerability.
 
-At this point, a CVE should be requested through GitHub Security Advisory, which should include the Report ID and a summary.
+### Secondary Contact
 
-Reference: [GitHub Security Advisories](https://docs.github.com/en/code-security/security-advisories)
+If you do not receive an acknowledgment of your report within 6 business days,
+or if you cannot find a private security contact for the project, you may
+contact the OpenJS Foundation CNA at <https://cna.openjsf.org/> (or
+`security@lists.openjsf.org`) for assistance.
+
+The CNA can help ensure your report is properly acknowledged, assist with
+coordinating disclosure timelines, and assign CVEs when necessary. This is a
+support mechanism to ensure security reports are handled appropriately across
+all OpenJS Foundation projects.
 
 ## The Fastify Security team
 
-The core team is responsible for the management of the security program and this
-policy and process.
+The core team is responsible for the management of the security program and
+this policy and process.
 
 Members of this team are expected to keep all information that they have
 privileged access to by being on the team completely private to the team. This
@@ -129,8 +180,6 @@ work as a member of the Fastify Core team.
 * [__KaKa Ng__](https://github.com/climba03003)
 * [__James Sumners__](https://github.com/jsumners),
   <https://x.com/jsumners79>, <https://www.npmjs.com/~jsumners>
-* [__Rafael Gonzaga__](https://github.com/RafaelGSS),
-  <https://x.com/_rafaelgss>, <https://www.npmjs.com/~rafaelgss>
 
 ## OpenSSF CII Best Practices
 
@@ -142,11 +191,9 @@ There are three “tiers”: passing, silver, and gold.
 We meet 100% of the “passing” criteria.
 
 ### Silver
-We meet 87% of the “silver” criteria. The gaps are as follows:
+We meet 87% of the "silver" criteria. The gaps are as follows:
   - we do not have a DCO or a CLA process for contributions.
-  - we do not currently document
-    “what the user can and cannot expect in terms of security” for our project.
-  - we do not currently document ”the architecture (aka high-level design)”
+  - we do not currently document "the architecture (aka high-level design)"
     for our project.
 
 ### Gold
@@ -157,4 +204,3 @@ We meet 70% of the “gold” criteria. The gaps are as follows:
     suggestion instead of a hard requirement.
   - There are a few unanswered questions around cryptography that are
     waiting for clarification.
-


### PR DESCRIPTION
## Summary
- sync `SECURITY.md` with the latest updates from of https://github.com/fastify/fastify/blob/main/SECURITY.md
- add the Threat Model section
- update vulnerability reporting/CVE guidance
- add Secondary Contact details
- align wording and OpenSSF criteria details

## Notes
- kept the repository-local advisory link reference (`[advisory]: ../../security/advisories/new`) instead of hardcoding a repository URL.
